### PR TITLE
Removed trailing comma that was causing an issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     "grunt-contrib-uglify": "^0.9.1",
     "grunt-contrib-cssmin": "^0.13.0",
     "grunt-svgmin": "^2.0.1",
-    "grunt-contrib-imagemin": "^0.9.4",
+    "grunt-contrib-imagemin": "^0.9.4"
   }
 }


### PR DESCRIPTION
it was throwing up this error while try to npm install

matt:gibweb matt$ npm install
npm ERR! install Couldn't read dependencies
npm ERR! Darwin 14.4.0
npm ERR! argv "node" "/usr/local/bin/npm" "install"
npm ERR! node v0.12.7
npm ERR! npm  v2.11.3
npm ERR! file /Users/matt/Sites/gibweb/package.json
npm ERR! code EJSONPARSE

npm ERR! Failed to parse json
npm ERR! Trailing comma in object at 30:3
npm ERR!   }
npm ERR!   ^
npm ERR! File: /Users/matt/Sites/gibweb/package.json
npm ERR! Failed to parse package.json data.
npm ERR! package.json must be actual JSON, not just JavaScript.
npm ERR! 
npm ERR! This is not a bug in npm.
npm ERR! Tell the package author to fix their package.json file. JSON.parse

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/matt/Sites/gibweb/npm-debug.log
